### PR TITLE
Fix key import dependency for rvm to install... rvm still not installed correctly. :-(

### DIFF
--- a/provision/projects/tasks/main.yml
+++ b/provision/projects/tasks/main.yml
@@ -116,6 +116,9 @@
   git: repo=git@github.com:nhshackday/nhshackday.github.io
       dest=/usr/lib/ohc/nhshackday.github.io update=yes
 
+- name: import keys for rvm install to work
+  shell: gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+
 - name: install rvm
   shell: \curl -L https://get.rvm.io | bash -s stable --autolibs=3 creates=~/.rvm
 


### PR DESCRIPTION
I don't want to spend time fixing your ansibles - but this solves the initial problem. It turns out that rvm appears to install but not in the place you're expecting it to:

```
failed: [default] => {"changed": true, "cmd": "~/.rvm/bin/rvm install --default 1.9.3 ", "delta": "0:00:00.017247", "end": "2015-03-11 12:02:28.307852", "rc": 127, "start": "2015-03-11 12:02:28.290605"}
stderr: /bin/sh: 1: /home/vagrant/.rvm/bin/rvm: not found

FATAL: all hosts have already failed -- aborting
```

(That's what happens when you try to install Ruby)

HTH